### PR TITLE
Refactor: Adjust ProjectDetail layout with section and aside

### DIFF
--- a/pages/src/app/components/projects/project-detail/project-detail.component.html
+++ b/pages/src/app/components/projects/project-detail/project-detail.component.html
@@ -1,44 +1,46 @@
 <section>
   <div *ngIf="project$ | async as project; else loadingOrNotFound">
     <button (click)="goBack()" i18n="Button to navigate back to the projects list@@projectDetailBackButton">Back to List</button>
-    <h2>{{ project.name }} <span class="project-status">({{ project.status }})</span></h2> <!-- Dynamic data -->
+    <div class="project-detail-layout">
+      <div class="main-content">
+        <h2>{{ project.name }} <span class="project-status">({{ project.status }})</span></h2> <!-- Dynamic data -->
 
-    <p>{{ project.description }}</p> <!-- Dynamic data -->
+        <p>{{ project.description }}</p> <!-- Dynamic data -->
 
-    <div *ngIf="project.technologies && project.technologies.length > 0">
-      <strong i18n="Label for technologies list in project detail@@projectDetailTechLabel">Technologies:</strong> {{ project.technologies.join(', ') }}
-    </div>
+        <div *ngIf="project.technologies && project.technologies.length > 0">
+          <strong i18n="Label for technologies list in project detail@@projectDetailTechLabel">Technologies:</strong> {{ project.technologies.join(', ') }}
+        </div>
 
-    <div *ngIf="project.repoUrl">
-      <strong i18n="Label for project repository link@@projectDetailRepoLabel">Repository:</strong> <a [href]="project.repoUrl" target="_blank">{{ project.repoUrl }}</a>
-    </div>
+        <div *ngIf="project.repoUrl">
+          <strong i18n="Label for project repository link@@projectDetailRepoLabel">Repository:</strong> <a [href]="project.repoUrl" target="_blank">{{ project.repoUrl }}</a>
+        </div>
 
-    <div *ngIf="project.architectureDiagramUrl" class="project-image-container">
-      <strong i18n="Label for project architecture diagram@@projectDetailArchDiagLabel">Architecture Diagram:</strong><br/>
-      <img [src]="project.architectureDiagramUrl" i18n-alt="Alternative text for project architecture diagram. {{project.name}} is the project name.@@projectDetailArchDiagAlt" [alt]="project.name + ' architecture diagram'" class="project-image">
-    </div>
-
-  </div>    
-  <aside>
-    
-     <div *ngIf="project.imageUrl" class="project-image-container">
-        <strong i18n="Label for project preview image@@projectDetailPreviewLabel">Preview:</strong><br/>
-        <img [src]="project.imageUrl" i18n-alt="Alternative text for project preview image. {{project.name}} is the project name.@@projectDetailPreviewAlt" [alt]="project.name + ' preview'" class="project-image">
+        <div *ngIf="project.architectureDiagramUrl" class="project-image-container">
+          <strong i18n="Label for project architecture diagram@@projectDetailArchDiagLabel">Architecture Diagram:</strong><br/>
+          <img [src]="project.architectureDiagramUrl" i18n-alt="Alternative text for project architecture diagram. {{project.name}} is the project name.@@projectDetailArchDiagAlt" [alt]="project.name + ' architecture diagram'" class="project-image">
+        </div>
       </div>
-    
-      <div *ngIf="project.relatedLinks && project.relatedLinks.length > 0" class="related-links">
-        <strong i18n="Label for related links section@@projectDetailRelatedLinksLabel">Related Links:</strong>
-        <ul>
-          <li *ngFor="let link of project.relatedLinks">
-            <a [href]="link.url" target="_blank">
-              <img *ngIf="link.iconUrl" [src]="link.iconUrl" i18n-alt="Alternative text for related link icon. {{link.name}} is the link name.@@projectDetailRelatedLinkIconAlt" [alt]="link.name + ' icon'" class="link-icon">
+
+      <aside>
+        <div *ngIf="project.imageUrl" class="project-image-container">
+          <strong i18n="Label for project preview image@@projectDetailPreviewLabel">Preview:</strong><br/>
+          <img [src]="project.imageUrl" i18n-alt="Alternative text for project preview image. {{project.name}} is the project name.@@projectDetailPreviewAlt" [alt]="project.name + ' preview'" class="project-image">
+        </div>
+
+        <div *ngIf="project.relatedLinks && project.relatedLinks.length > 0" class="related-links">
+          <strong i18n="Label for related links section@@projectDetailRelatedLinksLabel">Related Links:</strong>
+          <ul>
+            <li *ngFor="let link of project.relatedLinks">
+              <a [href]="link.url" target="_blank">
+                <img *ngIf="link.iconUrl" [src]="link.iconUrl" i18n-alt="Alternative text for related link icon. {{link.name}} is the link name.@@projectDetailRelatedLinkIconAlt" [alt]="link.name + ' icon'" class="link-icon">
                 {{ link.name }} <!-- Dynamic data (link name) -->
-            </a>
-          </li>
-        </ul>
-      </div>
-    
-  </aside>
+              </a>
+            </li>
+          </ul>
+        </div>
+      </aside>
+    </div>
+  </div>
   <ng-template #loadingOrNotFound>
     <p *ngIf="projectNotFound" i18n="Message displayed when a project is not found@@projectDetailNotFound">Project not found.</p>
     <p *ngIf="!projectNotFound" i18n="Message displayed while project details are loading@@projectDetailLoading">Loading project details...</p>

--- a/pages/src/app/components/projects/project-detail/project-detail.component.scss
+++ b/pages/src/app/components/projects/project-detail/project-detail.component.scss
@@ -42,3 +42,37 @@ button {
 button:hover {
   background-color: #0056b3;
 }
+
+.project-detail-layout {
+  display: flex;
+  flex-wrap: wrap; // Allow wrapping on smaller screens if necessary
+}
+
+.main-content {
+  flex: 2; // Takes twice the space of aside
+  padding-right: 20px; // Space between main content and aside
+}
+
+aside {
+  flex: 1; // Takes one part of the space
+  // Additional styling for aside can go here if needed
+  // For example, if you want to ensure it doesn't get too narrow:
+  // min-width: 250px;
+}
+
+// Responsive adjustments: On smaller screens, stack them
+@media (max-width: 768px) {
+  .project-detail-layout {
+    flex-direction: column;
+  }
+
+  .main-content {
+    padding-right: 0; // Remove padding when stacked
+    margin-bottom: 20px; // Add some space below main content when stacked
+  }
+
+  aside {
+    // Reset flex properties if needed, or adjust width
+    flex-basis: 100%; // Make aside take full width when stacked
+  }
+}


### PR DESCRIPTION
- Modified project-detail.component.html to move the aside element within the correct scope and introduced wrapper divs for layout.
- Updated project-detail.component.scss to implement a flexbox-based two-column layout for the project details page.
- The main content (description, diagram) now sits on the left, and the project image and related links are in an aside panel on the right.
- Added responsive styles to stack the layout on smaller screens.