### PR TITLE
Fix: Correct KeyboardEvent type casting in ModalComponent

### DIFF
--- a/pages/src/app/components/modal/modal.component.ts
+++ b/pages/src/app/components/modal/modal.component.ts
@@ -51,7 +51,7 @@ export class ModalComponent implements OnInit {
   }
 
   // Optional: Close modal on Escape key press
-  @HostListener('document:keydown.escape', ['$event as KeyboardEvent'])
+  @HostListener('document:keydown.escape', ['$event'])
   onKeydownHandler(event: KeyboardEvent) {
     // The decorator handles the key check, so direct call to close is fine
     this.modalService.close();


### PR DESCRIPTION
The HostListener for the escape key was incorrectly casting the event, leading to a compile-time error. This change removes the problematic cast '$event as KeyboardEvent' and relies on Angular's event handling to correctly provide a KeyboardEvent to the handler method.