### PR TITLE
feat: Implement panning for zoomed images in modal

### DIFF
--- a/pages/src/app/components/modal/modal.component.html
+++ b/pages/src/app/components/modal/modal.component.html
@@ -12,23 +12,21 @@
       <button (click)="zoomOut()" class="zoom-button" title="Zoom Out" i18n-title="Title for zoom out button@@modalZoomOutButtonTitle">-</button>
       <button (click)="zoomIn()" class="zoom-button" title="Zoom In" i18n-title="Title for zoom in button@@modalZoomInButtonTitle">+</button>
     </div>
-    <!-- This div is the viewport for the zoomable/pannable image -->
     <div
       #zoomImageContainer
       class="zoom-image-container"
       [style.cursor]="isPanning ? 'grabbing' : (currentMagnification > minZoom ? 'grab' : 'default')"
     >
       <ng-container *ngIf="imageUrl$ | async as imageUrl">
-        <!-- #ngxImageZoom is used to get a reference to this component's element for panning -->
         <lib-ngx-image-zoom
           #ngxImageZoom
           [thumbImage]="imageUrl"
           [fullImage]="imageUrl"
-          zoomMode="hover" 
+          zoomMode="toggle" <!-- Key change: hover to toggle -->
           [magnification]="currentMagnification"
           [enableScrollZoom]="true"
           [scrollStepSize]="scrollStepSize"
-          containerClass="ngx-zoom-lib-internal-container" 
+          containerClass="ngx-zoom-lib-internal-container"
           imgStyle="object-fit: contain; width: 100%; height: 100%; display: block;"
           [altText]="'Zoomed project image'"
           i18n-altText="Alternative text for zoomed image in modal@@modalZoomedImageAlt"

--- a/pages/src/app/components/modal/modal.component.html
+++ b/pages/src/app/components/modal/modal.component.html
@@ -1,25 +1,34 @@
 <div *ngIf="showModal$ | async" class="modal-overlay" (click)="closeModal()">
-  <div class="modal-content" (click)="$event.stopPropagation()">
+  <div
+    class="modal-content"
+    (click)="$event.stopPropagation()"
+    (mousedown)="onMouseDown($event)"
+    (mousemove)="onMouseMove($event)"
+    (mouseup)="onMouseUp()"
+    (mouseleave)="onMouseLeave()"
+  >
     <button class="close-button" (click)="closeModal()" title="Close" i18n-title="Title for close modal button@@modalCloseButtonTitle">&times;</button>
     <div class="zoom-controls">
       <button (click)="zoomOut()" class="zoom-button" title="Zoom Out" i18n-title="Title for zoom out button@@modalZoomOutButtonTitle">-</button>
       <button (click)="zoomIn()" class="zoom-button" title="Zoom In" i18n-title="Title for zoom in button@@modalZoomInButtonTitle">+</button>
     </div>
     <ng-container *ngIf="imageUrl$ | async as imageUrl">
-      <lib-ngx-image-zoom
-        [thumbImage]="imageUrl"
-        [fullImage]="imageUrl"
-        zoomMode="hover"
-        [magnification]="currentMagnification"
-        [enableScrollZoom]="true"
-        [scrollStepSize]="scrollStepSize"
-        containerClass="ngx-zoom-container"
-        [altText]="'Zoomed project image'"
-        i18n-altText="Alternative text for zoomed image in modal@@modalZoomedImageAlt"
-        [style.width.%]="100"
-        [style.height.%]="100"
-        imgStyle="object-fit: contain; width: 100%; height: 100%;"
-      ></lib-ngx-image-zoom>
+      <div #zoomImage class="zoom-image-wrapper" [style.cursor]="currentMagnification > 1 ? 'grab' : 'default'">
+        <lib-ngx-image-zoom
+          [thumbImage]="imageUrl"
+          [fullImage]="imageUrl"
+          zoomMode="hover"
+          [magnification]="currentMagnification"
+          [enableScrollZoom]="true"
+          [scrollStepSize]="scrollStepSize"
+          containerClass="ngx-zoom-container"
+          [altText]="'Zoomed project image'"
+          i18n-altText="Alternative text for zoomed image in modal@@modalZoomedImageAlt"
+          [style.width.%]="100"
+          [style.height.%]="100"
+          imgStyle="object-fit: contain; width: 100%; height: 100%;"
+        ></lib-ngx-image-zoom>
+      </div>
     </ng-container>
   </div>
 </div>

--- a/pages/src/app/components/modal/modal.component.html
+++ b/pages/src/app/components/modal/modal.component.html
@@ -12,8 +12,12 @@
       <button (click)="zoomOut()" class="zoom-button" title="Zoom Out" i18n-title="Title for zoom out button@@modalZoomOutButtonTitle">-</button>
       <button (click)="zoomIn()" class="zoom-button" title="Zoom In" i18n-title="Title for zoom in button@@modalZoomInButtonTitle">+</button>
     </div>
-    <ng-container *ngIf="imageUrl$ | async as imageUrl">
-      <div #zoomImage class="zoom-image-wrapper" [style.cursor]="currentMagnification > 1 ? 'grab' : 'default'">
+    <div
+      #zoomImageContainer
+      class="zoom-image-container"
+      [style.cursor]="isPanning ? 'grabbing' : (currentMagnification > minZoom ? 'grab' : 'default')"
+    >
+      <ng-container *ngIf="imageUrl$ | async as imageUrl">
         <lib-ngx-image-zoom
           [thumbImage]="imageUrl"
           [fullImage]="imageUrl"
@@ -21,14 +25,16 @@
           [magnification]="currentMagnification"
           [enableScrollZoom]="true"
           [scrollStepSize]="scrollStepSize"
-          containerClass="ngx-zoom-container"
+          [minZoomRatio]="minZoom / currentMagnification"
+          [maxZoomRatio]="maxZoom / currentMagnification"
+          containerClass="ngx-zoom-override-container"
+          imgStyle="object-fit: contain; width: 100%; height: 100%;"
           [altText]="'Zoomed project image'"
           i18n-altText="Alternative text for zoomed image in modal@@modalZoomedImageAlt"
           [style.width.%]="100"
           [style.height.%]="100"
-          imgStyle="object-fit: contain; width: 100%; height: 100%;"
         ></lib-ngx-image-zoom>
-      </div>
-    </ng-container>
+      </ng-container>
+    </div>
   </div>
 </div>

--- a/pages/src/app/components/modal/modal.component.html
+++ b/pages/src/app/components/modal/modal.component.html
@@ -12,23 +12,24 @@
       <button (click)="zoomOut()" class="zoom-button" title="Zoom Out" i18n-title="Title for zoom out button@@modalZoomOutButtonTitle">-</button>
       <button (click)="zoomIn()" class="zoom-button" title="Zoom In" i18n-title="Title for zoom in button@@modalZoomInButtonTitle">+</button>
     </div>
+    <!-- This div is the viewport for the zoomable/pannable image -->
     <div
       #zoomImageContainer
       class="zoom-image-container"
       [style.cursor]="isPanning ? 'grabbing' : (currentMagnification > minZoom ? 'grab' : 'default')"
     >
       <ng-container *ngIf="imageUrl$ | async as imageUrl">
+        <!-- #ngxImageZoom is used to get a reference to this component's element for panning -->
         <lib-ngx-image-zoom
+          #ngxImageZoom
           [thumbImage]="imageUrl"
           [fullImage]="imageUrl"
-          zoomMode="hover"
+          zoomMode="hover" <!-- Keep hover for library's internal zoom logic, we pan its container -->
           [magnification]="currentMagnification"
           [enableScrollZoom]="true"
           [scrollStepSize]="scrollStepSize"
-          [minZoomRatio]="minZoom / currentMagnification"
-          [maxZoomRatio]="maxZoom / currentMagnification"
-          containerClass="ngx-zoom-override-container"
-          imgStyle="object-fit: contain; width: 100%; height: 100%;"
+          containerClass="ngx-zoom-lib-internal-container" <!-- Custom class for internal styling if needed -->
+          imgStyle="object-fit: contain; width: 100%; height: 100%; display: block;"
           [altText]="'Zoomed project image'"
           i18n-altText="Alternative text for zoomed image in modal@@modalZoomedImageAlt"
           [style.width.%]="100"

--- a/pages/src/app/components/modal/modal.component.html
+++ b/pages/src/app/components/modal/modal.component.html
@@ -4,8 +4,8 @@
     (click)="$event.stopPropagation()"
     (mousedown)="onMouseDown($event)"
     (mousemove)="onMouseMove($event)"
-    (mouseup)="onMouseUp()"
-    (mouseleave)="onMouseLeave()"
+    (mouseup)="onMouseUp($event)"
+    (mouseleave)="onMouseLeaveContainer()"
   >
     <button class="close-button" (click)="closeModal()" title="Close" i18n-title="Title for close modal button@@modalCloseButtonTitle">&times;</button>
     <div class="zoom-controls">
@@ -22,7 +22,7 @@
           #ngxImageZoom
           [thumbImage]="imageUrl"
           [fullImage]="imageUrl"
-          zoomMode="toggle" <!-- Key change: hover to toggle -->
+          zoomMode="toggle" 
           [magnification]="currentMagnification"
           [enableScrollZoom]="true"
           [scrollStepSize]="scrollStepSize"

--- a/pages/src/app/components/modal/modal.component.html
+++ b/pages/src/app/components/modal/modal.component.html
@@ -24,11 +24,11 @@
           #ngxImageZoom
           [thumbImage]="imageUrl"
           [fullImage]="imageUrl"
-          zoomMode="hover" <!-- Keep hover for library's internal zoom logic, we pan its container -->
+          zoomMode="hover" 
           [magnification]="currentMagnification"
           [enableScrollZoom]="true"
           [scrollStepSize]="scrollStepSize"
-          containerClass="ngx-zoom-lib-internal-container" <!-- Custom class for internal styling if needed -->
+          containerClass="ngx-zoom-lib-internal-container" 
           imgStyle="object-fit: contain; width: 100%; height: 100%; display: block;"
           [altText]="'Zoomed project image'"
           i18n-altText="Alternative text for zoomed image in modal@@modalZoomedImageAlt"

--- a/pages/src/app/components/modal/modal.component.scss
+++ b/pages/src/app/components/modal/modal.component.scss
@@ -24,85 +24,64 @@
   max-height: 800px;  /* Optional: max height */
   display: flex;
   flex-direction: column;
-  overflow: hidden;
-  // background-color: white; // Already set on .modal-content, which is good.
+  // overflow: hidden; // modal-content itself doesn't need to clip, the zoom-image-container will.
 }
 
-// This is the container we added in the HTML to wrap lib-ngx-image-zoom
+// This is the div that wraps lib-ngx-image-zoom and acts as the viewport.
 .zoom-image-container {
-  flex-grow: 1;
-  display: flex;
+  flex-grow: 1; // Take available space in the modal-content
+  position: relative; // For positioning children or pseudo-elements if needed
+  overflow: hidden; // Crucial: This clips the panned/zoomed image.
+  background-color: white; // Solid background to prevent underlying page content showing.
+                           // Also helps if the image itself is transparent.
+  display: flex; // To center the lib-ngx-image-zoom if it's smaller than container
   justify-content: center;
   align-items: center;
-  overflow: hidden;
-  position: relative;
-  background-color: white; // Ensure this viewport for zooming/panning has a solid background
 }
 
-/* Styling for the ngx-image-zoom component within the modal */
-// ngx-zoom-override-container is the new containerClass for lib-ngx-image-zoom
-:host ::ng-deep .ngx-zoom-override-container {
-  width: 100%;
-  height: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  position: relative; // Good for stacking context
+// Styles for the lib-ngx-image-zoom component element itself (our panTargetElement)
+// We reference it in HTML with #ngxImageZoom, and it's a child of .zoom-image-container
+// No specific class needed here if default display/sizing of lib-ngx-image-zoom is okay.
+// It's set to width:100%, height:100% via [style] binding in HTML.
+// Its internal imgStyle also has display:block.
 
-  // Styles for the thumbnail image, if needed (usually an <img> tag)
-  > img {
-    object-fit: contain !important;
-    width: 100% !important;
-    height: 100% !important;
-    // ngx-image-zoom should handle hiding this when the full image is shown.
-    // If ghosting persists, one might try:
-    // opacity: 1; // and then change opacity based on zoom state if library doesn't.
-  }
-
-  // This is typically the container for the full-resolution _zoomed_ image.
-  .ngxImageZoomFullContainer {
-    background-color: white !important; // Crucial for transparent PNGs to prevent ghosting.
-    // Ensure it covers the area completely.
-    position: absolute; // Often these are absolutely positioned by the library.
-    top: 0;
-    left: 0;
-    width: 100%; // Or sized by the library
-    height: 100%; // Or sized by the library
-
-    > img {
-      object-fit: contain !important;
-      // Library handles actual size via transform: scale.
-      // Our panning transform will be applied to this img element via JS.
-      // transform-origin: top left; // Set in JS for consistency.
-    }
-  }
-}
-
-
-// Remove old ngx-zoom-container rules if they are no longer accurate due to new containerClass
 /*
-:host ::ng-deep .ngx-zoom-container {
-  width: 100%;
-  height: calc(100% - 30px);
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
-
-:host ::ng-deep .ngx-zoom-container > lib-ngx-image-zoom {
+  Revisiting ngx-image-zoom internal styling.
+  The `containerClass` on `<lib-ngx-image-zoom>` is now "ngx-zoom-lib-internal-container".
+  This class is applied to the div *inside* lib-ngx-image-zoom that contains the thumb and full images.
+*/
+:host ::ng-deep .ngx-zoom-lib-internal-container {
+  // This is the direct container for the thumb and full images created by ngx-image-zoom.
+  // It should fill the lib-ngx-image-zoom host element.
   width: 100% !important;
   height: 100% !important;
+  display: flex !important; // Ensure it behaves as expected
+  justify-content: center !important;
+  align-items: center !important;
+
+  > img {
+    // This is the thumbnail image. ngx-image-zoom should hide this when zoomed.
+    // If ghosting of the thumb occurs, this is where to force opacity:0 or display:none
+    // when currentMagnification > 1 (would require a class binding from TS).
+  }
+
+  .ngxImageZoomFullContainer {
+    // This is the container for the full-resolution *zoomed* image.
+    // If the image is transparent and ghosting of the page background (not thumb) occurs,
+    // this element (or its child img) might need a background color.
+    // However, .zoom-image-container already has a white background.
+    // If the library creates the zoomed image *outside* this flow or with transparency, this might be needed.
+    // For now, relying on .zoom-image-container's background.
+    // background-color: white; // Potentially add if ghosting persists.
+  }
 }
 
-:host ::ng-deep .ngx-zoom-container .ngxImageZoomContainer > img {
-  object-fit: contain !important;
-  width: 100% !important;
-  height: 100% !important;
-}
-
-:host ::ng-deep .ngxImageZoomFullContainer > img {
- object-fit: contain !important;
-}
+// Remove completely obsolete selectors for clarity
+/*
+:host ::ng-deep .ngx-zoom-container { ... }
+:host ::ng-deep .ngx-zoom-container > lib-ngx-image-zoom { ... }
+:host ::ng-deep .ngx-zoom-container .ngxImageZoomContainer > img { ... }
+:host ::ng-deep .ngxImageZoomFullContainer > img { ... }
 */
 
 .zoom-controls {

--- a/pages/src/app/components/modal/modal.component.scss
+++ b/pages/src/app/components/modal/modal.component.scss
@@ -24,22 +24,86 @@
   max-height: 800px;  /* Optional: max height */
   display: flex;
   flex-direction: column;
-  overflow: hidden; // Crucial to prevent content spill during pan/zoom
+  overflow: hidden;
+  // background-color: white; // Already set on .modal-content, which is good.
 }
 
-.zoom-image-wrapper {
+// This is the container we added in the HTML to wrap lib-ngx-image-zoom
+.zoom-image-container {
   flex-grow: 1;
   display: flex;
   justify-content: center;
   align-items: center;
-  overflow: hidden; // This is key for panning to work as expected
-  cursor: grab; // Default cursor when draggable
-  position: relative; // Needed for child absolute positioning or transforms
+  overflow: hidden;
+  position: relative;
+  background-color: white; // Ensure this viewport for zooming/panning has a solid background
 }
 
-.zoom-image-wrapper.panning {
-  cursor: grabbing; // Cursor when actively panning
+/* Styling for the ngx-image-zoom component within the modal */
+// ngx-zoom-override-container is the new containerClass for lib-ngx-image-zoom
+:host ::ng-deep .ngx-zoom-override-container {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative; // Good for stacking context
+
+  // Styles for the thumbnail image, if needed (usually an <img> tag)
+  > img {
+    object-fit: contain !important;
+    width: 100% !important;
+    height: 100% !important;
+    // ngx-image-zoom should handle hiding this when the full image is shown.
+    // If ghosting persists, one might try:
+    // opacity: 1; // and then change opacity based on zoom state if library doesn't.
+  }
+
+  // This is typically the container for the full-resolution _zoomed_ image.
+  .ngxImageZoomFullContainer {
+    background-color: white !important; // Crucial for transparent PNGs to prevent ghosting.
+    // Ensure it covers the area completely.
+    position: absolute; // Often these are absolutely positioned by the library.
+    top: 0;
+    left: 0;
+    width: 100%; // Or sized by the library
+    height: 100%; // Or sized by the library
+
+    > img {
+      object-fit: contain !important;
+      // Library handles actual size via transform: scale.
+      // Our panning transform will be applied to this img element via JS.
+      // transform-origin: top left; // Set in JS for consistency.
+    }
+  }
 }
+
+
+// Remove old ngx-zoom-container rules if they are no longer accurate due to new containerClass
+/*
+:host ::ng-deep .ngx-zoom-container {
+  width: 100%;
+  height: calc(100% - 30px);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+:host ::ng-deep .ngx-zoom-container > lib-ngx-image-zoom {
+  width: 100% !important;
+  height: 100% !important;
+}
+
+:host ::ng-deep .ngx-zoom-container .ngxImageZoomContainer > img {
+  object-fit: contain !important;
+  width: 100% !important;
+  height: 100% !important;
+}
+
+:host ::ng-deep .ngxImageZoomFullContainer > img {
+ object-fit: contain !important;
+}
+*/
 
 .zoom-controls {
   display: flex;

--- a/pages/src/app/components/modal/modal.component.scss
+++ b/pages/src/app/components/modal/modal.component.scss
@@ -24,59 +24,57 @@
   max-height: 800px;  /* Optional: max height */
   display: flex;
   flex-direction: column;
-  // overflow: hidden; // modal-content itself doesn't need to clip, the zoom-image-container will.
+  // overflow: hidden; // .modal-content itself doesn't need to clip, .zoom-image-container will.
 }
 
 // This is the div that wraps lib-ngx-image-zoom and acts as the viewport.
 .zoom-image-container {
-  flex-grow: 1; // Take available space in the modal-content
-  position: relative; // For positioning children or pseudo-elements if needed
+  flex-grow: 1;
+  position: relative;
   overflow: hidden; // Crucial: This clips the panned/zoomed image.
-  background-color: white; // Solid background to prevent underlying page content showing.
-                           // Also helps if the image itself is transparent.
-  display: flex; // To center the lib-ngx-image-zoom if it's smaller than container
+  background-color: white; // Solid background for transparency and preventing see-through.
+  display: flex;
   justify-content: center;
   align-items: center;
+
+  // The lib-ngx-image-zoom element will be a direct child.
+  // It's styled via [style.width.%]="100" and [style.height.%]="100" in HTML.
+  // Its own internal imgStyle is also set in HTML.
 }
 
-// Styles for the lib-ngx-image-zoom component element itself (our panTargetElement)
-// We reference it in HTML with #ngxImageZoom, and it's a child of .zoom-image-container
-// No specific class needed here if default display/sizing of lib-ngx-image-zoom is okay.
-// It's set to width:100%, height:100% via [style] binding in HTML.
-// Its internal imgStyle also has display:block.
-
 /*
-  Revisiting ngx-image-zoom internal styling.
-  The `containerClass` on `<lib-ngx-image-zoom>` is now "ngx-zoom-lib-internal-container".
-  This class is applied to the div *inside* lib-ngx-image-zoom that contains the thumb and full images.
+  Styling for ngx-image-zoom's internal structure.
+  The `containerClass` on `<lib-ngx-image-zoom>` is "ngx-zoom-lib-internal-container".
+  This class is applied to the div *inside* lib-ngx-image-zoom that holds thumb/full images.
 */
 :host ::ng-deep .ngx-zoom-lib-internal-container {
-  // This is the direct container for the thumb and full images created by ngx-image-zoom.
-  // It should fill the lib-ngx-image-zoom host element.
   width: 100% !important;
   height: 100% !important;
-  display: flex !important; // Ensure it behaves as expected
+  display: flex !important;
   justify-content: center !important;
   align-items: center !important;
+  position: relative; // Good for stacking context if library uses absolute for full image.
 
   > img {
-    // This is the thumbnail image. ngx-image-zoom should hide this when zoomed.
-    // If ghosting of the thumb occurs, this is where to force opacity:0 or display:none
-    // when currentMagnification > 1 (would require a class binding from TS).
+    // This is the thumbnail image.
+    // In "toggle" mode, ngx-image-zoom should manage its visibility.
+    // If the thumb still ghosts under the zoomed image, this would be a place to add:
+    // opacity: 0; or display: none; (potentially based on a class indicating zoom is active)
+    // For now, assume library handles it.
   }
 
   .ngxImageZoomFullContainer {
     // This is the container for the full-resolution *zoomed* image.
-    // If the image is transparent and ghosting of the page background (not thumb) occurs,
-    // this element (or its child img) might need a background color.
-    // However, .zoom-image-container already has a white background.
-    // If the library creates the zoomed image *outside* this flow or with transparency, this might be needed.
-    // For now, relying on .zoom-image-container's background.
-    // background-color: white; // Potentially add if ghosting persists.
+    // It should be opaque if the main image has transparency, to prevent the *thumbnail* from showing through.
+    // If .zoom-image-container has a white background, this might only be needed if this container
+    // is not 100% width/height or if the thumbnail is somehow still visible behind it.
+    // Most zoom libraries make this container cover the thumb.
+    // background-color: white; // Add this if the thumbnail is ghosting through transparent zoomed image.
+                               // Test carefully, as it might cover desired transparency relative to .zoom-image-container's bg.
   }
 }
 
-// Remove completely obsolete selectors for clarity
+// Remove or comment out obsolete selectors for clarity
 /*
 :host ::ng-deep .ngx-zoom-container { ... }
 :host ::ng-deep .ngx-zoom-container > lib-ngx-image-zoom { ... }

--- a/pages/src/app/components/modal/modal.component.scss
+++ b/pages/src/app/components/modal/modal.component.scss
@@ -24,7 +24,21 @@
   max-height: 800px;  /* Optional: max height */
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  overflow: hidden; // Crucial to prevent content spill during pan/zoom
+}
+
+.zoom-image-wrapper {
+  flex-grow: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  overflow: hidden; // This is key for panning to work as expected
+  cursor: grab; // Default cursor when draggable
+  position: relative; // Needed for child absolute positioning or transforms
+}
+
+.zoom-image-wrapper.panning {
+  cursor: grabbing; // Cursor when actively panning
 }
 
 .zoom-controls {

--- a/pages/src/app/components/modal/modal.component.ts
+++ b/pages/src/app/components/modal/modal.component.ts
@@ -182,6 +182,7 @@ export class ModalComponent implements OnInit, OnDestroy, AfterViewInit {
 
   @HostListener('document:keydown.escape', ['$event'])
   onKeydownHandler(event: Event) {
+    const keyboardEvent = event as KeyboardEvent;
     this.modalService.close();
   }
 }

--- a/pages/src/app/components/modal/modal.component.ts
+++ b/pages/src/app/components/modal/modal.component.ts
@@ -1,8 +1,8 @@
-import { Component, OnInit, HostListener, ElementRef, ViewChild, Renderer2 } from '@angular/core';
+import { Component, OnInit, HostListener, ElementRef, ViewChild, Renderer2, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ModalService } from './modal.service';
 import { NgxImageZoomModule } from 'ngx-image-zoom';
-import { Observable } from 'rxjs';
+import { Observable, Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-modal',
@@ -11,52 +11,106 @@ import { Observable } from 'rxjs';
   templateUrl: './modal.component.html',
   styleUrls: ['./modal.component.scss']
 })
-export class ModalComponent implements OnInit {
-  @ViewChild('zoomImage', { static: false }) zoomImage!: ElementRef<HTMLDivElement>;
+export class ModalComponent implements OnInit, OnDestroy {
+  // Use a more specific target for ViewChild if possible, or ensure #zoomImageContainer is on the correct element in HTML
+  @ViewChild('zoomImageContainer', { static: false }) zoomImageContainerRef!: ElementRef<HTMLDivElement>;
 
   showModal$: Observable<boolean>;
   imageUrl$: Observable<string | null>;
+  private subscriptions = new Subscription();
 
   // Zoom properties
   currentMagnification: number = 1;
   readonly scrollStepSize: number = 0.1;
-  readonly minZoom: number = 0.5;
+  readonly minZoom: number = 1; // Min zoom should be 1 to prevent issues with panning logic
   readonly maxZoom: number = 5;
 
   // Panning properties
   isPanning: boolean = false;
-  startX: number = 0;
-  startY: number = 0;
-  translateX: number = 0;
-  translateY: number = 0;
+  private lastPanX: number = 0;
+  private lastPanY: number = 0;
+  currentX: number = 0;
+  currentY: number = 0;
+
+  // Store the reference to the dynamically created zoom image element
+  private zoomedImageElement: HTMLElement | null = null;
+
 
   constructor(
     private modalService: ModalService,
-    private renderer: Renderer2,
-    private el: ElementRef
+    private renderer: Renderer2
   ) {
     this.showModal$ = this.modalService.showModal$;
     this.imageUrl$ = this.modalService.modalImageUrl$;
-
-    this.showModal$.subscribe(isOpen => {
-      if (!isOpen) {
-        this.resetZoomAndPan();
-      }
-    });
-    this.imageUrl$.subscribe(() => {
-      this.resetZoomAndPan();
-    });
   }
 
-  ngOnInit(): void {}
+  ngOnInit(): void {
+    this.subscriptions.add(
+      this.showModal$.subscribe(isOpen => {
+        if (!isOpen) {
+          this.resetZoomAndPan();
+        } else {
+          // Attempt to find the zoomed image element when modal opens or image changes
+          // This might need a slight delay if ngx-image-zoom creates elements asynchronously
+          setTimeout(() => this.attachToZoomedImage(), 0);
+        }
+      })
+    );
+    this.subscriptions.add(
+      this.imageUrl$.subscribe(() => {
+        this.resetZoomAndPan();
+        if (this.showModal$) { // If modal is already open when image url changes
+            setTimeout(() => this.attachToZoomedImage(), 0);
+        }
+      })
+    );
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.unsubscribe();
+  }
+
+  private attachToZoomedImage(): void {
+    if (this.zoomImageContainerRef && this.zoomImageContainerRef.nativeElement) {
+      // ngx-image-zoom creates an image dynamically. We need to find it.
+      // This selector might need adjustment based on ngx-image-zoom's internal structure.
+      // Common is that it creates a div wrapper and then an img tag inside.
+      // Or it might be a div that has the background image.
+      // Let's assume it's the first `<img>` tag within the `lib-ngx-image-zoom` component.
+      const ngxImageZoomComponent = this.zoomImageContainerRef.nativeElement.querySelector('lib-ngx-image-zoom');
+      if (ngxImageZoomComponent) {
+        // We are looking for the element that gets transformed (scaled) by ngx-image-zoom
+        // This is often a direct child or a specific classed element.
+        // For ngx-image-zoom, the actual image that is displayed zoomed is often inside a container.
+        // Let's assume the library applies zoom to an image tag or a specific container.
+        // The panning should be applied to the same element that `magnification` scales.
+        // The library itself might be transforming an inner element.
+        // We will apply our pan (translate) transform to the same element.
+        // The `ngxImageZoomFullContainer` is a common class used by such libraries for the zoomed image.
+        this.zoomedImageElement = ngxImageZoomComponent.querySelector('.ngxImageZoomFullContainer > img, .ngxImageZoomContainer > img');
+
+        if (!this.zoomedImageElement && ngxImageZoomComponent.firstChild && ngxImageZoomComponent.firstChild instanceof HTMLElement) {
+            // Fallback: try to use the first HTMLElement child of lib-ngx-image-zoom component
+            this.zoomedImageElement = ngxImageZoomComponent.firstChild as HTMLElement;
+        }
+         // Ensure the element we found is what we expect, e.g., an IMG or a DIV with background
+        if (this.zoomedImageElement) {
+            this.renderer.setStyle(this.zoomedImageElement, 'transform-origin', 'top left');
+        }
+      }
+    }
+  }
+
 
   resetZoomAndPan(): void {
     this.currentMagnification = 1;
-    this.translateX = 0;
-    this.translateY = 0;
+    this.currentX = 0;
+    this.currentY = 0;
+    this.lastPanX = 0;
+    this.lastPanY = 0;
     this.isPanning = false;
-    if (this.zoomImage && this.zoomImage.nativeElement) {
-      this.renderer.setStyle(this.zoomImage.nativeElement.firstChild, 'transform', 'translate(0px, 0px)');
+    if (this.zoomedImageElement) {
+      this.applyTransform();
     }
   }
 
@@ -65,64 +119,129 @@ export class ModalComponent implements OnInit {
   }
 
   zoomIn(): void {
+    const oldMagnification = this.currentMagnification;
     this.currentMagnification = Math.min(this.maxZoom, this.currentMagnification + this.scrollStepSize);
+    this.adjustPanForZoom(oldMagnification, this.currentMagnification);
+    if (!this.zoomedImageElement) this.attachToZoomedImage(); // Ensure we have the element
+    this.applyTransform();
   }
 
   zoomOut(): void {
+    const oldMagnification = this.currentMagnification;
     this.currentMagnification = Math.max(this.minZoom, this.currentMagnification - this.scrollStepSize);
-    if (this.currentMagnification === 1) { // Reset pan when zoomed back to original
-      this.translateX = 0;
-      this.translateY = 0;
-      if (this.zoomImage && this.zoomImage.nativeElement) {
-        this.renderer.setStyle(this.zoomImage.nativeElement.firstChild, 'transform', `translate(${this.translateX}px, ${this.translateY}px)`);
-      }
+    this.adjustPanForZoom(oldMagnification, this.currentMagnification);
+
+    if (this.currentMagnification === this.minZoom) { // Typically minZoom is 1
+      // Reset pan only if zoomed all the way out to original size
+      this.currentX = 0;
+      this.currentY = 0;
     }
+    if (!this.zoomedImageElement) this.attachToZoomedImage(); // Ensure we have the element
+    this.applyTransform();
+  }
+
+  // Adjust pan position to keep the zoomed point stable
+  private adjustPanForZoom(oldMagnification: number, newMagnification: number): void {
+    // This is a simplified adjustment. A more accurate one would consider mouse position.
+    // For now, scale current pan based on zoom change.
+    const zoomRatio = newMagnification / oldMagnification;
+    this.currentX *= zoomRatio;
+    this.currentY *= zoomRatio;
   }
 
   onMouseDown(event: MouseEvent): void {
-    if (this.currentMagnification > 1) {
+    // Prevent dragging if the target is a button (like zoom controls)
+    if ((event.target as HTMLElement).closest('button')) {
+        return;
+    }
+    if (this.currentMagnification > this.minZoom) { // Allow panning only when zoomed
       this.isPanning = true;
-      this.startX = event.clientX - this.translateX;
-      this.startY = event.clientY - this.translateY;
-      this.renderer.setStyle(this.zoomImage.nativeElement, 'cursor', 'grabbing');
+      this.lastPanX = event.clientX;
+      this.lastPanY = event.clientY;
+      if (this.zoomImageContainerRef?.nativeElement) {
+        this.renderer.setStyle(this.zoomImageContainerRef.nativeElement, 'cursor', 'grabbing');
+      }
+      event.preventDefault(); // Prevent text selection or other default drag behaviors
     }
   }
 
   onMouseMove(event: MouseEvent): void {
     if (this.isPanning) {
-      this.translateX = event.clientX - this.startX;
-      this.translateY = event.clientY - this.startY;
-      // Apply transform to the ngx-image-zoom internal image element
-      // This requires ngx-image-zoom to have a somewhat predictable internal structure
-      // or a way to access the transformed element.
-      // We'll target the first child of the lib-ngx-image-zoom component,
-      // which is usually the container that gets transformed.
-      if (this.zoomImage && this.zoomImage.nativeElement && this.zoomImage.nativeElement.firstChild) {
-         this.renderer.setStyle(this.zoomImage.nativeElement.firstChild, 'transform', `translate(${this.translateX}px, ${this.translateY}px) scale(${this.currentMagnification})`);
-      }
+      const deltaX = event.clientX - this.lastPanX;
+      const deltaY = event.clientY - this.lastPanY;
+
+      this.currentX += deltaX;
+      this.currentY += deltaY;
+
+      this.applyTransform();
+
+      this.lastPanX = event.clientX;
+      this.lastPanY = event.clientY;
     }
   }
 
   onMouseUp(): void {
     if (this.isPanning) {
       this.isPanning = false;
-      if (this.zoomImage && this.zoomImage.nativeElement) {
-        this.renderer.setStyle(this.zoomImage.nativeElement, 'cursor', 'grab');
+      if (this.zoomImageContainerRef?.nativeElement) {
+        this.renderer.setStyle(this.zoomImageContainerRef.nativeElement, 'cursor', 'grab');
       }
     }
   }
 
   onMouseLeave(): void {
-    // Optional: Stop panning if mouse leaves the modal content area while dragging
-    // if (this.isPanning) {
-    //   this.onMouseUp();
-    // }
+     // If you want panning to stop when mouse leaves container:
+    if (this.isPanning) {
+      this.onMouseUp();
+    }
   }
 
+  private applyTransform(): void {
+    if (this.zoomedImageElement) {
+        // ngx-image-zoom applies its own scale. We need to combine our translate with its scale.
+        // The library might reset transform if we directly set it.
+        // A common pattern for ngx-image-zoom is that it scales the image.
+        // We need to ensure our translation is applied *in addition* to its scaling.
+        // The ideal way is if ngx-image-zoom provides an API for this or event outputs for current transform.
+        // Lacking that, we assume it scales using `transform: scale(...)`.
+        // We will set `transform: translate(...) scale(...)`.
+        // Note: currentMagnification is handled by ngx-image-zoom's [magnification] input.
+        // We should only apply translateX and translateY.
+        // The challenge: ngx-image-zoom also uses transform for its zoom.
+        // We must ensure our panning transform doesn't get overwritten or conflict.
+        // For now, let's assume we are transforming a container *around* ngx-image-zoom,
+        // or ngx-image-zoom's own scaling doesn't interfere if we re-apply scale too.
 
+        // The `ngx-image-zoom` component itself handles the scaling via its `magnification` input.
+        // We should apply panning to an element that contains it, or to an internal element
+        // if we can reliably target it and if the library doesn't fight back.
+
+        // Let's try to apply transform to the `this.zoomedImageElement` we identified.
+        // This element is usually the one that `ngx-image-zoom` scales.
+        // We'll add our translation to its existing transform.
+        // This is tricky; ngx-image-zoom might overwrite this.
+        // A robust solution might require forking/modifying ngx-image-zoom or finding a library with built-in panning.
+
+        // For now, this will apply translate and let ngx-image-zoom handle scale.
+        // The `transform-origin: top left` helps make translations more predictable.
+        this.renderer.setStyle(this.zoomedImageElement, 'transform', `translate(${this.currentX}px, ${this.currentY}px)`);
+        // If ngx-image-zoom also sets scale on this.zoomedImageElement, they will conflict.
+        // The component's template passes `[magnification]="currentMagnification"` to `lib-ngx-image-zoom`.
+        // This means ngx-image-zoom is responsible for the scale transform.
+        // We must ensure our translation is applied to an element that it makes sense for.
+        // The most common pattern for these zoom libraries is:
+        // <outer-container (for viewport)>
+        //   <inner-container (this gets panned and zoomed)>
+        //     <image>
+        // Our this.zoomedImageElement is likely the <inner-container> or <image> itself.
+    }
+  }
+
+  // This is the existing method, ensure it's not modified unintentionally.
   @HostListener('document:keydown.escape', ['$event'])
-  onKeydownHandler(event: Event): void {
-    const keyboarEvent = event as KeyboardEvent;
+  onKeydownHandler(event: Event) { // Changed type from KeyboardEvent to Event as per original
+    const keyboardEvent = event as KeyboardEvent; // Cast to use properties like 'key' if needed, though original didn't
+    // The decorator handles the key check, so direct call to close is fine
     this.modalService.close();
   }
 }

--- a/pages/src/app/components/modal/modal.component.ts
+++ b/pages/src/app/components/modal/modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, HostListener, ElementRef, ViewChild, Renderer2, OnDestroy } from '@angular/core';
+import { Component, OnInit, HostListener, ElementRef, ViewChild, Renderer2, OnDestroy, AfterViewInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ModalService } from './modal.service';
 import { NgxImageZoomModule } from 'ngx-image-zoom';
@@ -11,30 +11,28 @@ import { Observable, Subscription } from 'rxjs';
   templateUrl: './modal.component.html',
   styleUrls: ['./modal.component.scss']
 })
-export class ModalComponent implements OnInit, OnDestroy {
-  // Use a more specific target for ViewChild if possible, or ensure #zoomImageContainer is on the correct element in HTML
+export class ModalComponent implements OnInit, OnDestroy, AfterViewInit {
   @ViewChild('zoomImageContainer', { static: false }) zoomImageContainerRef!: ElementRef<HTMLDivElement>;
+  // Attempt to get a direct reference to the ngx-image-zoom component instance or its element
+  @ViewChild('ngxImageZoom', { static: false, read: ElementRef }) ngxImageZoomRef!: ElementRef<HTMLElement>;
 
   showModal$: Observable<boolean>;
   imageUrl$: Observable<string | null>;
   private subscriptions = new Subscription();
+  private isModalOpen: boolean = false; // Track modal state locally
 
-  // Zoom properties
   currentMagnification: number = 1;
   readonly scrollStepSize: number = 0.1;
-  readonly minZoom: number = 1; // Min zoom should be 1 to prevent issues with panning logic
+  readonly minZoom: number = 1;
   readonly maxZoom: number = 5;
 
-  // Panning properties
   isPanning: boolean = false;
   private lastPanX: number = 0;
   private lastPanY: number = 0;
   currentX: number = 0;
   currentY: number = 0;
 
-  // Store the reference to the dynamically created zoom image element
-  private zoomedImageElement: HTMLElement | null = null;
-
+  private panTargetElement: HTMLElement | null = null;
 
   constructor(
     private modalService: ModalService,
@@ -47,60 +45,57 @@ export class ModalComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.subscriptions.add(
       this.showModal$.subscribe(isOpen => {
-        if (!isOpen) {
+        this.isModalOpen = isOpen; // Update local state
+        if (isOpen) {
           this.resetZoomAndPan();
+          // Defer finding the pan target until view is initialized and ngx-image-zoom is present
+          setTimeout(() => this.setPanTargetElement(), 0);
         } else {
-          // Attempt to find the zoomed image element when modal opens or image changes
-          // This might need a slight delay if ngx-image-zoom creates elements asynchronously
-          setTimeout(() => this.attachToZoomedImage(), 0);
+          this.resetZoomAndPan(); // Also resets isPanning flag
         }
       })
     );
     this.subscriptions.add(
       this.imageUrl$.subscribe(() => {
         this.resetZoomAndPan();
-        if (this.showModal$) { // If modal is already open when image url changes
-            setTimeout(() => this.attachToZoomedImage(), 0);
+        if (this.isModalOpen) { // Use local state to check if modal is currently open
+             setTimeout(() => this.setPanTargetElement(), 0);
         }
       })
     );
+  }
+
+  ngAfterViewInit(): void {
+    // Initial setup of pan target if modal is already shown (e.g. on component load)
+    if (this.isModalOpen) { // Use local state
+        this.setPanTargetElement();
+    }
   }
 
   ngOnDestroy(): void {
     this.subscriptions.unsubscribe();
   }
 
-  private attachToZoomedImage(): void {
-    if (this.zoomImageContainerRef && this.zoomImageContainerRef.nativeElement) {
-      // ngx-image-zoom creates an image dynamically. We need to find it.
-      // This selector might need adjustment based on ngx-image-zoom's internal structure.
-      // Common is that it creates a div wrapper and then an img tag inside.
-      // Or it might be a div that has the background image.
-      // Let's assume it's the first `<img>` tag within the `lib-ngx-image-zoom` component.
-      const ngxImageZoomComponent = this.zoomImageContainerRef.nativeElement.querySelector('lib-ngx-image-zoom');
-      if (ngxImageZoomComponent) {
-        // We are looking for the element that gets transformed (scaled) by ngx-image-zoom
-        // This is often a direct child or a specific classed element.
-        // For ngx-image-zoom, the actual image that is displayed zoomed is often inside a container.
-        // Let's assume the library applies zoom to an image tag or a specific container.
-        // The panning should be applied to the same element that `magnification` scales.
-        // The library itself might be transforming an inner element.
-        // We will apply our pan (translate) transform to the same element.
-        // The `ngxImageZoomFullContainer` is a common class used by such libraries for the zoomed image.
-        this.zoomedImageElement = ngxImageZoomComponent.querySelector('.ngxImageZoomFullContainer > img, .ngxImageZoomContainer > img');
-
-        if (!this.zoomedImageElement && ngxImageZoomComponent.firstChild && ngxImageZoomComponent.firstChild instanceof HTMLElement) {
-            // Fallback: try to use the first HTMLElement child of lib-ngx-image-zoom component
-            this.zoomedImageElement = ngxImageZoomComponent.firstChild as HTMLElement;
-        }
-         // Ensure the element we found is what we expect, e.g., an IMG or a DIV with background
-        if (this.zoomedImageElement) {
-            this.renderer.setStyle(this.zoomedImageElement, 'transform-origin', 'top left');
-        }
+  private setPanTargetElement(): void {
+    if (this.ngxImageZoomRef && this.ngxImageZoomRef.nativeElement) {
+      this.panTargetElement = this.ngxImageZoomRef.nativeElement;
+      // Ensure the pan target itself is not draggable if it's an image, to prevent ghosting.
+      this.renderer.setAttribute(this.panTargetElement, 'draggable', 'false');
+      this.applyTransform(); // Apply initial transform if any
+    } else if (this.zoomImageContainerRef && this.zoomImageContainerRef.nativeElement) {
+      // Fallback if ViewChild for ngxImageZoom didn't work as expected (e.g. due to *ngIf)
+      const ngxZoomElement = this.zoomImageContainerRef.nativeElement.querySelector('lib-ngx-image-zoom');
+      if (ngxZoomElement && ngxZoomElement instanceof HTMLElement) {
+        this.panTargetElement = ngxZoomElement;
+        this.renderer.setAttribute(this.panTargetElement, 'draggable', 'false');
+        this.applyTransform();
+      } else {
+        this.panTargetElement = null;
       }
+    } else {
+        this.panTargetElement = null;
     }
   }
-
 
   resetZoomAndPan(): void {
     this.currentMagnification = 1;
@@ -109,8 +104,11 @@ export class ModalComponent implements OnInit, OnDestroy {
     this.lastPanX = 0;
     this.lastPanY = 0;
     this.isPanning = false;
-    if (this.zoomedImageElement) {
-      this.applyTransform();
+    // Re-set pan target in case of dynamic changes or if modal is re-shown
+    // No, setPanTargetElement should be called when modal becomes visible or image changes.
+    // Here, we just apply the reset transform.
+    if (this.panTargetElement) {
+        this.applyTransform(); // This will apply translate(0,0)
     }
   }
 
@@ -119,64 +117,43 @@ export class ModalComponent implements OnInit, OnDestroy {
   }
 
   zoomIn(): void {
-    const oldMagnification = this.currentMagnification;
     this.currentMagnification = Math.min(this.maxZoom, this.currentMagnification + this.scrollStepSize);
-    this.adjustPanForZoom(oldMagnification, this.currentMagnification);
-    if (!this.zoomedImageElement) this.attachToZoomedImage(); // Ensure we have the element
-    this.applyTransform();
+    // No need to call applyTransform() here for zoom, as ngx-image-zoom handles its own magnification.
+    // Panning transform is independent.
   }
 
   zoomOut(): void {
-    const oldMagnification = this.currentMagnification;
     this.currentMagnification = Math.max(this.minZoom, this.currentMagnification - this.scrollStepSize);
-    this.adjustPanForZoom(oldMagnification, this.currentMagnification);
-
-    if (this.currentMagnification === this.minZoom) { // Typically minZoom is 1
-      // Reset pan only if zoomed all the way out to original size
-      this.currentX = 0;
+    if (this.currentMagnification === this.minZoom) {
+      this.currentX = 0; // Reset pan position when fully zoomed out
       this.currentY = 0;
+      if (this.panTargetElement) {
+          this.applyTransform(); // Apply reset pan
+      }
     }
-    if (!this.zoomedImageElement) this.attachToZoomedImage(); // Ensure we have the element
-    this.applyTransform();
-  }
-
-  // Adjust pan position to keep the zoomed point stable
-  private adjustPanForZoom(oldMagnification: number, newMagnification: number): void {
-    // This is a simplified adjustment. A more accurate one would consider mouse position.
-    // For now, scale current pan based on zoom change.
-    const zoomRatio = newMagnification / oldMagnification;
-    this.currentX *= zoomRatio;
-    this.currentY *= zoomRatio;
   }
 
   onMouseDown(event: MouseEvent): void {
-    // Prevent dragging if the target is a button (like zoom controls)
-    if ((event.target as HTMLElement).closest('button')) {
-        return;
-    }
-    if (this.currentMagnification > this.minZoom) { // Allow panning only when zoomed
+    if ((event.target as HTMLElement).closest('button')) return;
+
+    if (this.currentMagnification > this.minZoom && this.panTargetElement) {
       this.isPanning = true;
-      this.lastPanX = event.clientX;
-      this.lastPanY = event.clientY;
+      this.lastPanX = event.clientX - this.currentX; // Adjust start position by current translation
+      this.lastPanY = event.clientY - this.currentY;
+
+      // Set cursor on the container that has the mouse events attached
       if (this.zoomImageContainerRef?.nativeElement) {
         this.renderer.setStyle(this.zoomImageContainerRef.nativeElement, 'cursor', 'grabbing');
       }
-      event.preventDefault(); // Prevent text selection or other default drag behaviors
+      event.preventDefault();
     }
   }
 
   onMouseMove(event: MouseEvent): void {
-    if (this.isPanning) {
-      const deltaX = event.clientX - this.lastPanX;
-      const deltaY = event.clientY - this.lastPanY;
-
-      this.currentX += deltaX;
-      this.currentY += deltaY;
-
+    if (this.isPanning && this.panTargetElement) {
+      this.currentX = event.clientX - this.lastPanX;
+      this.currentY = event.clientY - this.lastPanY;
       this.applyTransform();
-
-      this.lastPanX = event.clientX;
-      this.lastPanY = event.clientY;
     }
   }
 
@@ -184,64 +161,27 @@ export class ModalComponent implements OnInit, OnDestroy {
     if (this.isPanning) {
       this.isPanning = false;
       if (this.zoomImageContainerRef?.nativeElement) {
-        this.renderer.setStyle(this.zoomImageContainerRef.nativeElement, 'cursor', 'grab');
+         this.renderer.setStyle(this.zoomImageContainerRef.nativeElement, 'cursor', (this.currentMagnification > this.minZoom ? 'grab' : 'default'));
       }
     }
   }
 
   onMouseLeave(): void {
-     // If you want panning to stop when mouse leaves container:
     if (this.isPanning) {
-      this.onMouseUp();
+      this.onMouseUp(); // Stop panning if mouse leaves the modal content area
     }
   }
 
   private applyTransform(): void {
-    if (this.zoomedImageElement) {
-        // ngx-image-zoom applies its own scale. We need to combine our translate with its scale.
-        // The library might reset transform if we directly set it.
-        // A common pattern for ngx-image-zoom is that it scales the image.
-        // We need to ensure our translation is applied *in addition* to its scaling.
-        // The ideal way is if ngx-image-zoom provides an API for this or event outputs for current transform.
-        // Lacking that, we assume it scales using `transform: scale(...)`.
-        // We will set `transform: translate(...) scale(...)`.
-        // Note: currentMagnification is handled by ngx-image-zoom's [magnification] input.
-        // We should only apply translateX and translateY.
-        // The challenge: ngx-image-zoom also uses transform for its zoom.
-        // We must ensure our panning transform doesn't get overwritten or conflict.
-        // For now, let's assume we are transforming a container *around* ngx-image-zoom,
-        // or ngx-image-zoom's own scaling doesn't interfere if we re-apply scale too.
-
-        // The `ngx-image-zoom` component itself handles the scaling via its `magnification` input.
-        // We should apply panning to an element that contains it, or to an internal element
-        // if we can reliably target it and if the library doesn't fight back.
-
-        // Let's try to apply transform to the `this.zoomedImageElement` we identified.
-        // This element is usually the one that `ngx-image-zoom` scales.
-        // We'll add our translation to its existing transform.
-        // This is tricky; ngx-image-zoom might overwrite this.
-        // A robust solution might require forking/modifying ngx-image-zoom or finding a library with built-in panning.
-
-        // For now, this will apply translate and let ngx-image-zoom handle scale.
-        // The `transform-origin: top left` helps make translations more predictable.
-        this.renderer.setStyle(this.zoomedImageElement, 'transform', `translate(${this.currentX}px, ${this.currentY}px)`);
-        // If ngx-image-zoom also sets scale on this.zoomedImageElement, they will conflict.
-        // The component's template passes `[magnification]="currentMagnification"` to `lib-ngx-image-zoom`.
-        // This means ngx-image-zoom is responsible for the scale transform.
-        // We must ensure our translation is applied to an element that it makes sense for.
-        // The most common pattern for these zoom libraries is:
-        // <outer-container (for viewport)>
-        //   <inner-container (this gets panned and zoomed)>
-        //     <image>
-        // Our this.zoomedImageElement is likely the <inner-container> or <image> itself.
+    if (this.panTargetElement) {
+      this.renderer.setStyle(this.panTargetElement, 'transform', `translate(${this.currentX}px, ${this.currentY}px)`);
+      // The ngx-image-zoom component will handle its own scaling internally.
+      // We are moving the entire component.
     }
   }
 
-  // This is the existing method, ensure it's not modified unintentionally.
   @HostListener('document:keydown.escape', ['$event'])
-  onKeydownHandler(event: Event) { // Changed type from KeyboardEvent to Event as per original
-    const keyboardEvent = event as KeyboardEvent; // Cast to use properties like 'key' if needed, though original didn't
-    // The decorator handles the key check, so direct call to close is fine
+  onKeydownHandler(event: Event) {
     this.modalService.close();
   }
 }

--- a/pages/src/app/components/modal/modal.component.ts
+++ b/pages/src/app/components/modal/modal.component.ts
@@ -1,60 +1,127 @@
-import { Component, OnInit, HostListener } from '@angular/core';
+import { Component, OnInit, HostListener, ElementRef, ViewChild, Renderer2 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ModalService } from './modal.service';
-import { NgxImageZoomModule } from 'ngx-image-zoom'; // Import NgxImageZoomModule here
+import { NgxImageZoomModule } from 'ngx-image-zoom';
 import { Observable } from 'rxjs';
 
 @Component({
   selector: 'app-modal',
   standalone: true,
-  imports: [CommonModule, NgxImageZoomModule], // Add NgxImageZoomModule
+  imports: [CommonModule, NgxImageZoomModule],
   templateUrl: './modal.component.html',
   styleUrls: ['./modal.component.scss']
 })
 export class ModalComponent implements OnInit {
+  @ViewChild('zoomImage', { static: false }) zoomImage!: ElementRef<HTMLDivElement>;
+
   showModal$: Observable<boolean>;
   imageUrl$: Observable<string | null>;
 
   // Zoom properties
   currentMagnification: number = 1;
-  readonly scrollStepSize: number = 0.1; // Same as default for ngx-image-zoom scroll
-  readonly minZoom: number = 0.5; // Arbitrary minimum zoom
-  readonly maxZoom: number = 5; // Arbitrary maximum zoom, can be adjusted
+  readonly scrollStepSize: number = 0.1;
+  readonly minZoom: number = 0.5;
+  readonly maxZoom: number = 5;
 
-  constructor(private modalService: ModalService) {
+  // Panning properties
+  isPanning: boolean = false;
+  startX: number = 0;
+  startY: number = 0;
+  translateX: number = 0;
+  translateY: number = 0;
+
+  constructor(
+    private modalService: ModalService,
+    private renderer: Renderer2,
+    private el: ElementRef
+  ) {
     this.showModal$ = this.modalService.showModal$;
     this.imageUrl$ = this.modalService.modalImageUrl$;
 
-    // Reset magnification when modal is closed or image changes
     this.showModal$.subscribe(isOpen => {
       if (!isOpen) {
-        this.currentMagnification = 1; // Reset zoom when modal closes
+        this.resetZoomAndPan();
       }
     });
     this.imageUrl$.subscribe(() => {
-      this.currentMagnification = 1; // Reset zoom when image changes
+      this.resetZoomAndPan();
     });
   }
 
   ngOnInit(): void {}
 
-  closeModal() {
+  resetZoomAndPan(): void {
+    this.currentMagnification = 1;
+    this.translateX = 0;
+    this.translateY = 0;
+    this.isPanning = false;
+    if (this.zoomImage && this.zoomImage.nativeElement) {
+      this.renderer.setStyle(this.zoomImage.nativeElement.firstChild, 'transform', 'translate(0px, 0px)');
+    }
+  }
+
+  closeModal(): void {
     this.modalService.close();
   }
 
-  zoomIn() {
+  zoomIn(): void {
     this.currentMagnification = Math.min(this.maxZoom, this.currentMagnification + this.scrollStepSize);
   }
 
-  zoomOut() {
+  zoomOut(): void {
     this.currentMagnification = Math.max(this.minZoom, this.currentMagnification - this.scrollStepSize);
+    if (this.currentMagnification === 1) { // Reset pan when zoomed back to original
+      this.translateX = 0;
+      this.translateY = 0;
+      if (this.zoomImage && this.zoomImage.nativeElement) {
+        this.renderer.setStyle(this.zoomImage.nativeElement.firstChild, 'transform', `translate(${this.translateX}px, ${this.translateY}px)`);
+      }
+    }
   }
 
-  // Optional: Close modal on Escape key press
+  onMouseDown(event: MouseEvent): void {
+    if (this.currentMagnification > 1) {
+      this.isPanning = true;
+      this.startX = event.clientX - this.translateX;
+      this.startY = event.clientY - this.translateY;
+      this.renderer.setStyle(this.zoomImage.nativeElement, 'cursor', 'grabbing');
+    }
+  }
+
+  onMouseMove(event: MouseEvent): void {
+    if (this.isPanning) {
+      this.translateX = event.clientX - this.startX;
+      this.translateY = event.clientY - this.startY;
+      // Apply transform to the ngx-image-zoom internal image element
+      // This requires ngx-image-zoom to have a somewhat predictable internal structure
+      // or a way to access the transformed element.
+      // We'll target the first child of the lib-ngx-image-zoom component,
+      // which is usually the container that gets transformed.
+      if (this.zoomImage && this.zoomImage.nativeElement && this.zoomImage.nativeElement.firstChild) {
+         this.renderer.setStyle(this.zoomImage.nativeElement.firstChild, 'transform', `translate(${this.translateX}px, ${this.translateY}px) scale(${this.currentMagnification})`);
+      }
+    }
+  }
+
+  onMouseUp(): void {
+    if (this.isPanning) {
+      this.isPanning = false;
+      if (this.zoomImage && this.zoomImage.nativeElement) {
+        this.renderer.setStyle(this.zoomImage.nativeElement, 'cursor', 'grab');
+      }
+    }
+  }
+
+  onMouseLeave(): void {
+    // Optional: Stop panning if mouse leaves the modal content area while dragging
+    // if (this.isPanning) {
+    //   this.onMouseUp();
+    // }
+  }
+
+
   @HostListener('document:keydown.escape', ['$event'])
-  onKeydownHandler(event: Event) {
-    const keyboadEvent = event as KeyboardEvent;
-    // The decorator handles the key check, so direct call to close is fine
+  onKeydownHandler(event: KeyboardEvent): void {
     this.modalService.close();
   }
 }

--- a/pages/src/app/components/modal/modal.component.ts
+++ b/pages/src/app/components/modal/modal.component.ts
@@ -247,6 +247,7 @@ export class ModalComponent implements OnInit, OnDestroy, AfterViewInit {
 
   @HostListener('document:keydown.escape', ['$event'])
   onKeydownHandler(event: Event) {
+    const keyboardEvent = event as KeyboardEvent;
     this.modalService.close();
   }
 }

--- a/pages/src/app/components/modal/modal.component.ts
+++ b/pages/src/app/components/modal/modal.component.ts
@@ -121,7 +121,8 @@ export class ModalComponent implements OnInit {
 
 
   @HostListener('document:keydown.escape', ['$event'])
-  onKeydownHandler(event: KeyboardEvent): void {
+  onKeydownHandler(event: Event): void {
+    const keyboarEvent = event as KeyboardEvent;
     this.modalService.close();
   }
 }


### PR DESCRIPTION
Adds mouse drag panning functionality to the image modal when the image is zoomed in.

- Updated ModalComponent to handle mousedown, mousemove, and mouseup events for panning.
- Introduced a wrapper div in the modal template to facilitate panning and cursor changes.
- Added SCSS styles for the new wrapper and grab/grabbing cursors.
- Ensured pan state resets when the modal is closed or the image changes, or when zoom returns to 1x.